### PR TITLE
New input and output option to rm_join_out.py

### DIFF
--- a/rm_join_out.py
+++ b/rm_join_out.py
@@ -1,6 +1,12 @@
 #! /usr/bin/python
 
-files = open("lista_out.txt")
+import sys
+
+try:
+        inp = sys.argv[1]
+        files = open(inp)
+except:
+        files = open("lista_out.txt")
 
 # process RM *.out file
 dict_count = {}
@@ -11,7 +17,11 @@ score   div. del. ins.  sequence                                     begin end  
 
 """
 
-outout = open("test.all.out", "w")
+try:
+        out_name = sys.argv[2]
+        outout = open(out_name,"w")
+except:
+        outout = open("test.all.out", "w")
 outout.write(header)
 
 def process_out(file):


### PR DESCRIPTION
With this changes is not mandatory to use "lista_out.txt" as input and "test.all.out" as output.
If you run the script with no options, it will run as before but with this changes you can pass the names of input and output
example:
 rm_join_out.py input.out output.out